### PR TITLE
Add basic meta tags with no favicon for now

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,23 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>DIAL UP DIGITAL</title>
+
+    <!-- DON'T FORGET TO FILL OUT OpenGraph FIELDS -->
+    <meta property="og:title" content="DIAL UP DIGITAL">
+    <meta property="og:description" content="Dial Up Digital is the technology arm of the multi-hyphenate creative collective and “family-owned business” Dial Up.">
+    <meta property="og:url" content="https://dialup.digital">
+    <meta property="og:type" content="website">
+    <meta property="og:image:width" content="600">
+    <meta property="og:image:height" content="600">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="DIAL UP DIGITAL">
+    <meta name="twitter:creator" content="@DialUpStuff">
+    <meta name="twitter:title" content="DIAL UP DIGITAL">
+    <meta name="twitter:description" content="Dial Up Digital is the technology arm of the multi-hyphenate creative collective and “family-owned business” Dial Up.">
+    <!-- at least 280px x 150px for Twitter (image must be < 1MB) -->
+    <meta name="twitter:domain" content="dialup.digital">
+
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Adds some basic tags. Can't really test how the platforms will render them until it's deployed