### PR TITLE
Implement button component

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,7 @@ export const Button: React.FC<ButtonProps> = ({
     <div
       aria-label={buttonLabel}
       role="button"
-      className={`button ${type}`}
+      className={`button ${type} ${className}`}
       onClick={onClick}
       {...restProps}
     >

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -9,21 +9,16 @@ export const Button: React.FC<ButtonProps> = ({
   type = "solid",
   onClick,
   ...restProps
-}) => {
-
-  return (
-    <div
-      aria-label={buttonLabel}
-      role="button"
-      className={`button ${type} ${className}`}
-      onClick={onClick}
-      {...restProps}
-    >
-      <Text type="h6" className="button-label">
-        {buttonLabel}
-      </Text>
-    </div>
-  );
-};
-
-export default Text;
+}) => (
+  <div
+    aria-label={buttonLabel}
+    role="button"
+    className={`button ${type} ${className}`}
+    onClick={onClick}
+    {...restProps}
+  >
+    <Text type="h6" className="button-label">
+      {buttonLabel}
+    </Text>
+  </div>
+);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ButtonProps } from "./ButtonTypes";
+import Text from "../Text/Text";
+import "./ButtonStyles.scss";
+
+export const Button: React.FC<ButtonProps> = ({
+  buttonLabel,
+  className = "",
+  type = "solid",
+  onClick,
+  ...restProps
+}) => {
+
+  return (
+    <div
+      aria-label={buttonLabel}
+      role="button"
+      className={`button ${type}`}
+      onClick={onClick}
+      {...restProps}
+    >
+      <Text type="h6" className="button-label">
+        {buttonLabel}
+      </Text>
+    </div>
+  );
+};
+
+export default Text;

--- a/src/components/Button/ButtonStyles.scss
+++ b/src/components/Button/ButtonStyles.scss
@@ -1,0 +1,36 @@
+@import "../../styles/variables";
+
+.button {
+  display: inline-block;
+  cursor: pointer;
+  padding: $spacing-x-small $spacing-large;
+  transition: opacity 0.2s;
+
+  & .button-label {
+    text-align: center;
+    padding: 0;
+    margin: 0;
+
+    /* Disable text highlight */
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  &.outline {
+    border: solid 0.25rem $white;
+    background: transparent;
+  }
+
+  &.solid {
+    background-color: $dream-blue;
+  }
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &:focus, &:active {
+    opacity: 0.70;
+  }
+}

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+type ButtonTypes = 'outline' | 'solid';
+
+export type ButtonProps = {
+  /**
+   * The label for the button
+   */
+  buttonLabel: string;
+
+  /**
+   * Custom class(es) to apply
+   */
+  className?: string;
+
+  /**
+   * The type of button, defaults to 'solid'
+   * 
+   * Supported types: 'outline' | 'solid'
+   */
+  type?: ButtonTypes;
+
+  /**
+   * Callback function to call when there is a button click
+   * 
+   * @returns
+   */
+  onClick: VoidFunction;
+} & React.HTMLProps<HTMLDivElement>;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
+export { Button } from "./Button/Button";
 export { Text } from "./Text/Text";
 export { SEO } from "./SEO/seo";


### PR DESCRIPTION
**Note: This is branched off of the `TextComponent` branch, need to merge that PR first**

Implementation of the `Button` component as outlined in the Figma specs. We currently have 2 types of Buttons defined, `solid` and `outline`.


**Solid Button Usage**
The solid button is the default, so no explicit type needs to be passed to the component
`<Button buttonLabel="request demo" onClick={() => alert("yerr")} />`
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/25678578/212795134-f2b6156d-5559-4027-b458-9a77741d8a9e.gif)


**Outline Button Usage**
We need to pass 'outline' to the `type` prop:
`<Button buttonLabel="request demo" onClick={() => alert("yerr")} type="outline" />`
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/25678578/212795240-8945f262-045a-4b7f-a1b6-ab6dad5448fd.gif)
