### PR TITLE
Remove footer style conflict

### DIFF
--- a/src/components/Footer/FooterStyles.scss
+++ b/src/components/Footer/FooterStyles.scss
@@ -1,4 +1,4 @@
-.footer {
+footer.footer {
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
Theres a conflict for the `.footer` class since its defined on both the app and the home page. This commit adds more specific selector in the Footer component styles file to resolve that conflict and ensure each page is recruiting the proper style definition