### PR TITLE
Keep Dial Up Logo in place at the top of the page

### DIFF
--- a/src/components/HeroSection/HeroSection.scss
+++ b/src/components/HeroSection/HeroSection.scss
@@ -9,16 +9,23 @@
 .content-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: min-content 1fr;
+  grid-template-areas:
+    "logo image"
+    "text image";
   flex: 1;
   gap: $spacing-x-small;
+  margin: $spacing-large 0;
 
   @include breakpoint('mobile') {
     grid-template-columns: 1fr;
+    margin: $spacing-x-small 0;
   }
 }
 
 .text-section {
-  margin-top: 15rem;
+  grid-area: text;
+  align-self: end;
 }
 
 .headline {
@@ -26,11 +33,21 @@
 }
 
 .image-section {
+  grid-area: image;
   display: flex;
   justify-content: center;
   align-items: center;
 
   @include breakpoint('mobile') {
     display: none;
+  }
+}
+
+.logo {
+  grid-area: logo;
+  height: 3rem;
+
+  @include breakpoint('mobile') {
+    height: 1.5rem;
   }
 }

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -4,12 +4,14 @@ import {
   Text,
 } from "../../components";
 import heroImg from "../../images/hero-img-placeholder.png";
+import logo from "../../images/dialup-retro-logo.png";
 import "./HeroSection.scss";
 
 export const HeroSection = () => (
     <section className="root">
       <div className="site-section">
         <div className="content-grid">
+          <img className="logo" src={logo} alt="Dial Up Logo" />
           <div className="text-section">
             <Text className="headline" type="h2">
               Event Apps for Everyone

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,13 +7,14 @@ import "./LayoutStyles.scss";
 export const Layout: React.FC<LayoutProps> = ({
   children,
   className,
+  hasHeader = true,
   ...restProps
 }) => (
   <div
     className={`layout ${className ? className : ''}`}
     {...restProps}
   >
-    <Header />
+    {hasHeader ? <Header /> : null}
     { children }
     <Footer />
   </div>

--- a/src/components/Layout/LayoutTypes.ts
+++ b/src/components/Layout/LayoutTypes.ts
@@ -5,4 +5,5 @@ export type LayoutProps = {
    * Main content to render
    */
   children?: any;
+  hasHeader?: boolean;
 } & React.HTMLProps<HTMLDivElement>;

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -13,7 +13,7 @@ import "../styles/global.scss";
 const IndexPage: React.FC<PageProps> = () => {
 
   return (
-    <Layout>
+    <Layout hasHeader={false}>
       <HeroSection />
       <main style={{padding: '64px 0'}}>
         <ImageTextBlock


### PR DESCRIPTION
We no longer want the dial up logo to show up as a fixed position element on the top of the page.

This PR adds a prop to the layout to optionally remove the header if needed.
<img width="1680" alt="Screenshot 2023-08-16 at 3 16 41 PM" src="https://github.com/DIALUPDIGITAL/portfolio/assets/6589909/cc4a540b-43f6-426f-add0-beed6210a150">
