### PR TITLE
Use env variable to optionally build site with apps home page

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Optiopns for this field are "company" or "apps"
+GATSBY_INDEX_PAGE_MODE="company"

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 # Optiopns for this field are "company" or "apps"
-GATSBY_INDEX_PAGE_MODE="apps"
+GATSBY_INDEX_PAGE_MODE="company"

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 # Optiopns for this field are "company" or "apps"
-GATSBY_INDEX_PAGE_MODE="company"
+GATSBY_INDEX_PAGE_MODE="apps"

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,5 +1,9 @@
 import type { GatsbyConfig } from "gatsby";
 
+require("dotenv").config({
+  path: `.env`,
+});
+
 const config: GatsbyConfig = {
   siteMetadata: {
     title: `DIAL UP DIGITAL`,

--- a/src/components/AppsPage/AppsPage.tsx
+++ b/src/components/AppsPage/AppsPage.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import type { PageProps } from "gatsby";
+import {
+  Button,
+  FeatureBlock,
+  HeroSection,
+  ImageTextBlock,
+  Layout,
+  SEO,
+  Text,
+} from "../../components";
+import featuresData from "../../data/features";
+import "../../styles/PageStyles/apps.scss";
+import { openDemoForm } from "../../utils/global";
+
+export const AppsPage: React.FC<PageProps> = () => {
+
+  return (
+    <Layout hasHeader={false}>
+      <HeroSection />
+      <main className="apps-container">
+        <ImageTextBlock
+          label="WHAT WE DO"
+          header="Festival Apps with Style"
+          body="Offering mobile applications that engage fans and improve the festival experience with thoughtful design methodology and industry-standard development practices."
+        />
+        <ImageTextBlock
+          label="WHO WE ARE"
+          header="Creative Technologists Building for Creative Events"
+          body="Sumn about the team, who we are, what we're into and what we like building or something?"
+        />
+        <ImageTextBlock
+          label="HOW IT'S GOING"
+          header="Demonstrated Success on  Stages Big and Small"
+          body="More about the metrics, downloads, reviews, praise we've gotten"
+        />
+      </main>
+      <div className="feature-section">
+        <div className="site-section">
+          <Text
+            className="feature-section__header"
+            type="h3"
+            mobileType="h6"
+          >Enhance your event experience</Text>
+          <div className="feature-section__grid">
+            {featuresData.map(feature => (
+              <FeatureBlock
+                iconSrc={feature.iconSrc}
+                title={feature.title}
+                description={feature.description}
+                key={feature.title}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="demo-section">
+        <div className="site-section">
+          <Text
+            className="demo-section__header"
+            type="h2"
+            mobileType="h6"
+          >Looking to build something amazing?  So are we.</Text>
+          <Button buttonLabel="request demo" onClick={openDemoForm}/>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from "react";
+import type { HeadFC, PageProps } from "gatsby";
+import { SEO, Text } from "../../components";
+import logo from "../../images/dialup-retro-logo.png";
+import "../../styles/global.scss";
+
+const setRandomBackgroundColor = () => {
+  const num = Math.random() * 100;
+  const bgColor =
+    num < 25
+      ? "#f6c875"
+      : num < 50
+      ? "#59d8cd"
+      : num < 75
+      ? "#ff5d5d"
+      : "#5fd5ff";
+
+  document.body.style.background = bgColor;
+};
+
+export const HomePage: React.FC<PageProps> = () => {
+  useEffect(() => {
+    setRandomBackgroundColor();
+  }, []);
+
+  return (
+    <div id="root" className="App">
+      <div className="contentContainer">
+        <div className="header">
+          <img className="logo" src={logo} alt="Dial Up Logo" />
+        </div>
+        <div className="body">
+          <Text type="h5" mobileType="h6">
+            {" "}
+            Dial Up Digital is the technology arm of the multi-hyphenate
+            creative collective and “family-owned business”{" "}
+            <a
+              href="http://dialupstuff.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Dial Up
+            </a>
+            . As artists and technologists, we work on creating unique digital
+            experiences at the intersection of music, technology and culture.{" "}
+          </Text>
+          <span>
+            <a href="mailto:hello@dialup.digital">Contact us</a>
+            to speak more about how we can work together.
+          </span>
+        </div>
+        <div className="footer">
+          <Text type="h6" className="footer-title"> stuff we've made </Text>
+          <a href="https://faith.rhizome.org/">BABY FAITH</a>
+          <a href="https://apps.apple.com/gb/app/the-summer-smash/id1467678976?ign-mpt=uo%3D2">
+            {" "}
+            SUMMER SMASH APP{" "}
+          </a>
+          <a href="https://tstng.co/"> TESTING - A$AP ROCKY </a>
+          <a href="http://dialupstuff.com/"> DIALUPSTUFF </a>
+          <a href="https://lyricallemonade.com"> LYRICAL LEMONADE WEBSITE </a>
+          <a href="https://psych.world/"> PSYCH WORLD </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
-import type { HeadFC, PageProps } from "gatsby";
-import { SEO, Text } from "../../components";
+import type { PageProps } from "gatsby";
+import { Text } from "../../components";
 import logo from "../../images/dialup-retro-logo.png";
 import "../../styles/global.scss";
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export { FeatureBlock } from "./FeatureBlock/FeatureBlock";
 export { Footer } from "./Footer/Footer";
 export { Header } from "./Header/Header";
 export { HeroSection } from "./HeroSection/HeroSection";
+export { HomePage } from "./HomePage/HomePage";
 export { ImageTextBlock } from "./ImageTextBlock/ImageTextBlock";
 export { Layout } from "./Layout/Layout";
 export { SEO } from "./SEO/SEO";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { AppsPage } from "./AppsPage/AppsPage";
 export { Button } from "./Button/Button";
 export { FeatureBlock } from "./FeatureBlock/FeatureBlock";
 export { Footer } from "./Footer/Footer";

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import type { HeadFC, PageProps } from "gatsby";
-import { AppsPage, SEO } from "../components";
+import { HomePage, SEO } from "../components";
 import "../styles/global.scss";
 
-const AppsRoutePage: React.FC<PageProps> = props => <AppsPage {...props} />;
+const HomeRoutePage: React.FC<PageProps> = props => <HomePage {...props} />;
 
-export default AppsRoutePage
+export default HomeRoutePage
 
 export const Head: HeadFC = () => <SEO />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,10 +3,8 @@ import type { HeadFC, PageProps } from "gatsby";
 import { AppsPage, HomePage, SEO } from "../components";
 import "../styles/global.scss";
 
-const IndexPage: React.FC<PageProps> = props => {
-  console.log("VALUE", process.env.GATSBY_INDEX_PAGE_MODE);
-  return process.env.GATSBY_INDEX_PAGE_MODE === "apps" ? <AppsPage {...props} /> : <HomePage {...props} />;
-}
+const IndexPage: React.FC<PageProps> = props =>
+  process.env.GATSBY_INDEX_PAGE_MODE === "apps" ? <AppsPage {...props} /> : <HomePage {...props} />;
 
 export default IndexPage
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,69 +1,10 @@
-import React, { useEffect } from "react";
+import React from "react";
 import type { HeadFC, PageProps } from "gatsby";
-import { SEO, Text } from "../components";
-import logo from "../images/dialup-retro-logo.png";
+import { HomePage, SEO } from "../components";
 import "../styles/global.scss";
 
-const setRandomBackgroundColor = () => {
-  const num = Math.random() * 100;
-  const bgColor =
-    num < 25
-      ? "#f6c875"
-      : num < 50
-      ? "#59d8cd"
-      : num < 75
-      ? "#ff5d5d"
-      : "#5fd5ff";
-
-  document.body.style.background = bgColor;
-};
-
-const IndexPage: React.FC<PageProps> = () => {
-  useEffect(() => {
-    setRandomBackgroundColor();
-  }, []);
-
-  return (
-    <div id="root" className="App">
-      <div className="contentContainer">
-        <div className="header">
-          <img className="logo" src={logo} alt="Dial Up Logo" />
-        </div>
-        <div className="body">
-          <Text type="h5" mobileType="h6">
-            {" "}
-            Dial Up Digital is the technology arm of the multi-hyphenate
-            creative collective and “family-owned business”{" "}
-            <a
-              href="http://dialupstuff.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Dial Up
-            </a>
-            . As artists and technologists, we work on creating unique digital
-            experiences at the intersection of music, technology and culture.{" "}
-          </Text>
-          <span>
-            <a href="mailto:hello@dialup.digital">Contact us</a>
-            to speak more about how we can work together.
-          </span>
-        </div>
-        <div className="footer">
-          <Text type="h6" className="footer-title"> stuff we've made </Text>
-          <a href="https://faith.rhizome.org/">BABY FAITH</a>
-          <a href="https://apps.apple.com/gb/app/the-summer-smash/id1467678976?ign-mpt=uo%3D2">
-            {" "}
-            SUMMER SMASH APP{" "}
-          </a>
-          <a href="https://tstng.co/"> TESTING - A$AP ROCKY </a>
-          <a href="http://dialupstuff.com/"> DIALUPSTUFF </a>
-          <a href="https://lyricallemonade.com"> LYRICAL LEMONADE WEBSITE </a>
-          <a href="https://psych.world/"> PSYCH WORLD </a>
-        </div>
-      </div>
-    </div>
-  );
+const IndexPage: React.FC<PageProps> = props => {
+  return <HomePage {...props} />
 }
 
 export default IndexPage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import type { HeadFC, PageProps } from "gatsby";
-import { HomePage, SEO } from "../components";
+import { AppsPage, HomePage, SEO } from "../components";
 import "../styles/global.scss";
 
 const IndexPage: React.FC<PageProps> = props => {
-  return <HomePage {...props} />
+  console.log("VALUE", process.env.GATSBY_INDEX_PAGE_MODE);
+  return process.env.GATSBY_INDEX_PAGE_MODE === "apps" ? <AppsPage {...props} /> : <HomePage {...props} />;
 }
 
 export default IndexPage

--- a/src/pages/testing/apps.tsx
+++ b/src/pages/testing/apps.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { HeadFC, PageProps } from "gatsby";
-import { AppsPage, SEO } from "../components";
-import "../styles/global.scss";
+import { AppsPage, SEO } from "../../components";
+import "../../styles/global.scss";
 
 const AppsRoutePage: React.FC<PageProps> = props => <AppsPage {...props} />;
 

--- a/src/pages/testing/home.tsx
+++ b/src/pages/testing/home.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { HeadFC, PageProps } from "gatsby";
-import { HomePage, SEO } from "../components";
-import "../styles/global.scss";
+import { HomePage, SEO } from "../../components";
+import "../../styles/global.scss";
 
 const HomeRoutePage: React.FC<PageProps> = props => <HomePage {...props} />;
 


### PR DESCRIPTION
This PR introduces an environment variable, `GATSBY_INDEX_PAGE_MODE`, which can be modified in Netlify in order to force the index page to render the content of the Apps page instead of the typical home page. This allows us to:
- Deploy a new project on Netlify with configurations specific to this apps site
- Check the env var to conditionally change behavior/content in SEO details depending on which version of the site we're rendering.

This PR also includes two routes, `/testing/apps` and `/testing//home`, that allow the developer to hard-load either version of the index page to support easier development 