### PR TITLE
Fix dynamic Text SSR conflict

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { TextProps } from "./TextTypes";
 import { useMediaQuery } from "../../hooks/use-media-query";
 
@@ -20,11 +20,12 @@ export const Text: React.FC<TextProps> = ({
   type = "p",
   ...restProps
 }) => {
-  let textType = type;
-  if (mobileType) {
-    const isMobile = useMediaQuery("(max-width: 768px)");
-    textType = isMobile && mobileType ? mobileType : type;
-  }
+  const isMobile = useMediaQuery("(max-width: 768px)");
+  const [textType, setTextType] = useState(type);
+
+  useEffect(() => {
+    setTextType(mobileType && isMobile ? mobileType : type);
+  }, [mobileType && isMobile]);
 
   return (
     <p className={`text ${mapTypeToClassName(textType)} ${className}`} {...restProps}>{children}</p>


### PR DESCRIPTION
Initial fix for dynamic className conflicts brought about by SSR. The current behavior as explained in Slack:

> if the initial screen size is mobile the text still appears at the desktop size. Have to start at desktop and adjust screen size down to mobile for the appropriate resizing to take place

This is the error that appears in the console:
```
Warning: Prop `className` did not match. Server: "text h3 " Client: "text h5 "
```

I won't dive too deep into explaining since this [Github issue](https://github.com/vercel/next.js/issues/9096) perfectly describes the behavior that I'm seeing.. 

Since the server side doesn't have a `window` to check for screen size, our media query hook defaults to desktop when populating the html page that is used client side during the first paint. Meaning, if a mobile device is used, the first paint uses the desktop sizes and a resize event would have to be triggered for a repaint. Unfortunately, this introduces a brief flicker on mobile where the text size flashes from desktop to mobile size... The flicker is not an ideal user experience and will be addressed in a follow-up PR after addressing higher priority items.