### PR TITLE
Replace the carousel package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
         "gatsby": "^5.3.3",
         "gatsby-plugin-manifest": "^5.3.1",
         "gatsby-plugin-sass": "^6.3.1",
+        "nuka-carousel": "^6.0.3",
         "postcss": "^8.4.20",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-responsive-carousel": "^3.2.23",
         "sass": "^1.57.1"
       },
       "devDependencies": {
@@ -4479,6 +4479,36 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
     },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/babel-jsx-utils": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-jsx-utils/-/babel-jsx-utils-1.1.0.tgz",
@@ -5199,11 +5229,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-    },
-    "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
@@ -10621,6 +10646,18 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nuka-carousel": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/nuka-carousel/-/nuka-carousel-6.0.3.tgz",
+      "integrity": "sha512-DYxCTp4xIv9/vfrfOr9FAmYizMr7AefL7mbqsBaBTwdrZ77mAsR/SNZtk+/KHJSuH+9gZLrugj/RC6qM8MJr+Q==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/null-loader": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-4.0.1.tgz",
@@ -12334,17 +12371,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-easy-swipe": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
-      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -12361,16 +12387,6 @@
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-responsive-carousel": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
-      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.5.8",
-        "react-easy-swipe": "^0.0.21"
       }
     },
     "node_modules/react-server-dom-webpack": {
@@ -18297,6 +18313,28 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
     },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "peer": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "peer": true
+        }
+      }
+    },
     "babel-jsx-utils": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/babel-jsx-utils/-/babel-jsx-utils-1.1.0.tgz",
@@ -18842,11 +18880,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-    },
-    "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -22899,6 +22932,12 @@
         "boolbase": "^1.0.0"
       }
     },
+    "nuka-carousel": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/nuka-carousel/-/nuka-carousel-6.0.3.tgz",
+      "integrity": "sha512-DYxCTp4xIv9/vfrfOr9FAmYizMr7AefL7mbqsBaBTwdrZ77mAsR/SNZtk+/KHJSuH+9gZLrugj/RC6qM8MJr+Q==",
+      "requires": {}
+    },
     "null-loader": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-4.0.1.tgz",
@@ -24063,14 +24102,6 @@
         "scheduler": "^0.23.0"
       }
     },
-    "react-easy-swipe": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
-      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -24085,16 +24116,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
-    },
-    "react-responsive-carousel": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
-      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "prop-types": "^15.5.8",
-        "react-easy-swipe": "^0.0.21"
-      }
     },
     "react-server-dom-webpack": {
       "version": "0.0.0-experimental-c8b778b7f-20220825",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "gatsby": "^5.3.3",
     "gatsby-plugin-manifest": "^5.3.1",
     "gatsby-plugin-sass": "^6.3.1",
+    "nuka-carousel": "^6.0.3",
     "postcss": "^8.4.20",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-responsive-carousel": "^3.2.23",
     "sass": "^1.57.1"
   },
   "devDependencies": {

--- a/src/components/AppsPage/AppsPage.tsx
+++ b/src/components/AppsPage/AppsPage.tsx
@@ -12,23 +12,9 @@ import {
 import { appsPageData, featuresData } from "../../data";
 import "../../styles/PageStyles/apps.scss";
 import { openDemoForm } from "../../utils/global";
-import "react-responsive-carousel/lib/styles/carousel.min.css";
-import { Carousel, CarouselProps } from "react-responsive-carousel";
+import Carousel from "nuka-carousel"
 
 export const AppsPage: React.FC<PageProps> = () => {
-  const renderCarouselIndicator: CarouselProps['renderIndicator'] = (
-    clickHandler,
-    isSelected,
-    index,
-    label,
-  ) => {
-    return (
-      <div
-        onClick={clickHandler}
-        className={`carousel__indicator-dot ${isSelected ? 'active' : ''}`}
-      ></div>
-    );
-  }
 
   return (
     <Layout hasHeader={false}>
@@ -62,15 +48,12 @@ export const AppsPage: React.FC<PageProps> = () => {
           </div>
           <div className="feature-section__carousel">
             <Carousel
-              autoPlay={true}
-              interval={5000}
-              swipeable={true}
-              emulateTouch={true}
-              infiniteLoop={true}
-              showThumbs={false}
-              showArrows={false}
-              showStatus={false}
-              renderIndicator={renderCarouselIndicator}
+              defaultControlsConfig={{
+                prevButtonStyle: {display: 'none'},
+                nextButtonStyle: {display: 'none'},
+                pagingDotsContainerClassName: 'paging-dot__container',
+                pagingDotsClassName: 'carousel__indicator-dot',
+              }}
             >
             {featuresData.map(feature => (
               <FeatureBlock

--- a/src/components/FeatureBlock/FeatureBlock.tsx
+++ b/src/components/FeatureBlock/FeatureBlock.tsx
@@ -13,6 +13,7 @@ export const FeatureBlock: React.FC<FeatureBlockProps> = ({
     <Text
       className="feature-block__title"
       type="h6"
+      mobileType="p+"
     >{title}</Text>
     <Text
       className="feature-block__description"

--- a/src/styles/PageStyles/apps.scss
+++ b/src/styles/PageStyles/apps.scss
@@ -24,24 +24,33 @@
   }
 }
 
-.carousel__indicator-dot {
-  background-color: $white;
-  border-radius: 100%;
-  cursor: pointer;
-  display: inline-block;
-  width: 0.75rem;
-  height: 0.75rem;
-  opacity: 0.55;
-  transition: 0.3s;
+.paging-dot__container {
+  top: 0 !important;
+  position: relative;
+  margin-top: $spacing-medium !important;
 
-  &.active {
-    background-color: $sophisticated-blue;
+  li.active .carousel__indicator-dot {
+    background-color: $sophisticated-blue !important;
     opacity: 1;
     scale: 1.1;
   }
 
-  & + & {
+  li + li {
     margin-left: $spacing-x-small;
+  }
+
+  button.carousel__indicator-dot {
+    background-color: $white !important;
+    border-radius: 100%;
+    cursor: pointer;
+    display: inline-block;
+    width: 0.75rem;
+    height: 0.75rem;
+    transition: 0.3s;
+  
+    svg {
+      display: none;
+    }
   }
 }
 
@@ -55,6 +64,19 @@
 
     @include breakpoint('mobile') {
       display: block;
+    }
+
+    .slider-container {
+      display: flex;
+      flex-flow: column-reverse;
+
+      div {
+        position: relative !important;
+      }
+
+      & .feature-block {
+        margin: 0 auto;
+      }
     }
 
     .carousel.carousel-slider {


### PR DESCRIPTION
The initial carousel package had a weird issue on mobile where the touch-swipe gesture didn't work. After debugging for a while I found that removing `height: 100%` from  `#__gatsby` and `#gatsby-focus-wrapper` made it work. I don't fully understand why that made it work, so I've switched to another package to avoid further (potentially undiagnosable) issues. Read up more on the new package [here](https://www.npmjs.com/package/nuka-carousel)

(At this point i couldve just implemented one from scratch lmaoo)