### PR TITLE
Proposal for 6-col Grid Implementation

### DIFF
--- a/src/components/AppsPage/AppsPage.tsx
+++ b/src/components/AppsPage/AppsPage.tsx
@@ -18,7 +18,7 @@ export const AppsPage: React.FC<PageProps> = () => {
   return (
     <Layout hasHeader={false}>
       <HeroSection />
-      <main className="apps-container">
+      <div className="apps-container">
         { appsPageData.map(block => (
           <ImageTextBlock
             key={block.label}
@@ -28,7 +28,7 @@ export const AppsPage: React.FC<PageProps> = () => {
             image={block.image}
           />
         ))}
-      </main>
+      </div>
       <div className="feature-section">
         <div className="site-section">
           <Text

--- a/src/components/AppsPageSection/AppsPageSection.tsx
+++ b/src/components/AppsPageSection/AppsPageSection.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { AppsPageSectionProps } from "./AppsPageSectionTypes";
+import "./AppsPageSectionStyles.scss";
+
+export const AppsPageSection: React.FC<AppsPageSectionProps> = ({ className, children }) => (
+  <section className={`apps-page-section ${className}`}>
+    {children}
+  </section>
+);

--- a/src/components/AppsPageSection/AppsPageSectionStyles.scss
+++ b/src/components/AppsPageSection/AppsPageSectionStyles.scss
@@ -4,12 +4,14 @@
 .apps-page-section {
   position: relative;
   display: grid;
-  padding: 4.5rem 0;
+  padding: $spacing-xx-large 0;
 
   grid-template-columns: [full-start] minmax(0, 1fr) [grid-start] repeat(3, minmax(0, 12rem)) [center-content-start] repeat(3, minmax(0, 12rem)) [grid-end] minmax(0, 1fr) [full-end];
   gap: $spacing-medium;
 
   @include breakpoint("mobile") {
+    padding: $spacing-large 0;
+
     grid-template-columns: [full-start] minmax(0, min-content) [grid-start] repeat(2, minmax(0, 1fr)) [grid-end] minmax(0, min-content) [full-end];
     gap: $spacing-x-small;
   }

--- a/src/components/AppsPageSection/AppsPageSectionStyles.scss
+++ b/src/components/AppsPageSection/AppsPageSectionStyles.scss
@@ -1,0 +1,16 @@
+@import "../../styles/variables.scss";
+@import "../../styles/breakpoints.scss";
+
+.apps-page-section {
+  position: relative;
+  display: grid;
+  padding: 4.5rem 0;
+
+  grid-template-columns: [full-start] minmax(0, 1fr) [grid-start] repeat(3, minmax(0, 12rem)) [center-content-start] repeat(3, minmax(0, 12rem)) [grid-end] minmax(0, 1fr) [full-end];
+  gap: $spacing-medium;
+
+  @include breakpoint("mobile") {
+    grid-template-columns: [full-start] minmax(0, min-content) [grid-start] repeat(2, minmax(0, 1fr)) [grid-end] minmax(0, min-content) [full-end];
+    gap: $spacing-x-small;
+  }
+}

--- a/src/components/AppsPageSection/AppsPageSectionTypes.tsx
+++ b/src/components/AppsPageSection/AppsPageSectionTypes.tsx
@@ -7,7 +7,7 @@ export type AppsPageSectionProps = {
   className?: string;
 
   /**
-   * Custom class(es) to apply
+   * Children that will be wrapped by this component
    */
    children?: React.ReactNode;
 };

--- a/src/components/AppsPageSection/AppsPageSectionTypes.tsx
+++ b/src/components/AppsPageSection/AppsPageSectionTypes.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+
+export type AppsPageSectionProps = {
+  /**
+   * Custom class(es) to apply
+   */
+  className?: string;
+
+  /**
+   * Custom class(es) to apply
+   */
+   children?: React.ReactNode;
+};

--- a/src/components/HeroSection/HeroSection.scss
+++ b/src/components/HeroSection/HeroSection.scss
@@ -3,85 +3,44 @@
 
 .hero {
   background: $bic_black;
-  display: flex;
-  position: relative;
+  background-image: url("../../images/crowd.jpg");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
 
-  &__bg {
-    overflow: hidden;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 0;
-
-    img {
-      height: 100%;
-      width: 100%;
-      object-fit: cover;
-    }
-  }
-
-  & .site-section {
-    z-index: 1;
-  }
+  // Creating rows in the explicit grid for the benefit of using the full possibilities of grid-row.
+  grid-template-rows: repeat(2, minmax(0, auto));
 }
 
-.content-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  grid-template-rows: min-content 1fr;
-  grid-template-areas:
-    "logo image"
-    "text image";
-  flex: 1;
-  gap: $spacing-x-small;
-  margin: $spacing-large 0;
-  z-index: 1;
+.nota-hero-logo {
+  grid-column: grid-start / span 3;
+  height: 4.25rem;
 
   @include breakpoint("mobile") {
-    grid-template-columns: 1fr;
-    margin: $spacing-x-small 0;
-    column-gap: 0;
-  }
-
-  .logo {
-    grid-area: logo;
-    height: 4.25rem;
-  
-    @include breakpoint("mobile") {
-      height: 2.5rem;
-      justify-self: center;
-    }
+    height: 2.5rem;
+    justify-self: center;
+    grid-column: grid-start / grid-end;
   }
 }
 
 .text-section {
-  grid-area: text;
+  grid-column: grid-start / span 3;
   align-self: end;
 
   @include breakpoint("mobile") {
-    display: flex;
-    flex-flow: column;
+    grid-column: grid-start / grid-end;
     align-items: center;
   }
+}
+
+.headline, .subheadline {
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .subheadline.text {
   margin-top: $spacing-medium;
   margin-bottom: 0;
-}
-
-@include breakpoint("mobile") {
-  .headline.text {
-    margin-bottom: $spacing-medium;
-  }
-
-  .headline,
-  .subheadline {
-    text-align: center;
-  }
 }
 
 .mobile-image-section {
@@ -93,11 +52,13 @@
 
   @include breakpoint("mobile") {
     display: block;
+    grid-column: grid-start / grid-end;
   }
 }
 
 .image-section {
-  grid-area: image;
+  grid-column: center-content-start / grid-end;
+  grid-row: 1 / -1;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -111,5 +72,16 @@
 
   @include breakpoint("mobile") {
     display: none;
+  }
+}
+
+@include breakpoint("mobile") {
+  .headline.text {
+    margin-bottom: $spacing-medium;
+  }
+
+  .headline,
+  .subheadline {
+    text-align: center;
   }
 }

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -1,37 +1,29 @@
 import React from "react";
-import { Button, Text } from "../../components";
+import { AppsPageSection, Button, Text } from "../../components";
 import heroImg from "../../images/2021_app_lineup.png";
 import logo from "../../images/logo.svg";
-import heroBg from "../../images/crowd.jpg";
 import mobileImg from "../../images/mobile_hero.png";
 import "./HeroSection.scss";
 import { openDemoForm } from "../../utils/global";
 
 export const HeroSection = () => (
-  <section className="hero">
-    <div className="hero__bg">
-      <img src={heroBg} />
-    </div>
-    <div className="site-section">
-      <div className="content-grid">
-        <img className="logo" src={logo} alt="Nota Logo" />
-        <div className="text-section">
-          <Text className="headline" type="h1" mobileType="h3">
-            Event Apps for Everyone
-          </Text>
-          <div className="mobile-image-section">
-            <img src={mobileImg} />
-          </div>
-          <Text className="subheadline" type="h3" mobileType="p">
-            Nota is powering the next generation of event apps for organizers
-            and attendees
-          </Text>
-          <Button buttonLabel="request demo" onClick={openDemoForm} />
-        </div>
-        <div className="image-section">
-          <img src={heroImg} />
-        </div>
+  <AppsPageSection className="hero">
+    <img className="nota-hero-logo" src={logo} alt="Nota Logo" />
+    <div className="text-section">
+      <Text className="headline" type="h1" mobileType="h3">
+        Event Apps for Everyone
+      </Text>
+      <div className="mobile-image-section">
+        <img src={mobileImg} />
       </div>
+      <Text className="subheadline" type="h3" mobileType="p">
+        Nota is powering the next generation of event apps for organizers
+        and attendees
+      </Text>
+      <Button buttonLabel="request demo" onClick={openDemoForm} />
     </div>
-  </section>
+    <div className="image-section">
+      <img src={heroImg} />
+    </div>
+  </AppsPageSection>
 );

--- a/src/components/Layout/LayoutStyles.scss
+++ b/src/components/Layout/LayoutStyles.scss
@@ -8,3 +8,4 @@
   display: flex;
   flex-direction: column;
 }
+

--- a/src/components/Layout/LayoutStyles.scss
+++ b/src/components/Layout/LayoutStyles.scss
@@ -8,4 +8,3 @@
   display: flex;
   flex-direction: column;
 }
-

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { AppsPage } from "./AppsPage/AppsPage";
+export { AppsPageSection } from "./AppsPageSection/AppsPageSection";
 export { Button } from "./Button/Button";
 export { FeatureBlock } from "./FeatureBlock/FeatureBlock";
 export { Footer } from "./Footer/Footer";


### PR DESCRIPTION
### Summary 
This PR uses the Hero section of the Apps page to propose an approach to setting up a new 6-column grid for the apps page. I think the overall benefit will be that, if we need to make revisions to the page as we learn more about the sales process, I believe that this will make making grid-aligned layouts faster. Curious about what folks think!

**Benefits of a Grid Implementation:**
- Simplifies layout questions, as the elements can be laid out relative to grid lines exactly as they appear in Figma.
- Reduces risk of misaligned elements between sections
- CSS Grid (in general) often reduces the need for nested elements, as their layout relations can be set up solely in CSS. This makes the layout easier to change (in compassion to Flexbox layouts) since all the layout changes can be made in the single SCSS file without touching markup.

**Approach:**
- Create a new AppsPageSection component, which will be used to wrap each section in the Splash page. This component implements a responsive grid with the following properties:
  - **Desktop**: 6-col grid with columns with two gutter columns on the left and right, for a total of 8 columns. The gutter columns expand and contract to keep the content central, the primary columns are 12rems in width (chosen to roughly match the sizing of the prior implementation). Lines are `full-start` (far left edge of the page), `full-end` (far left edge of the page), `grid-start` (start of the primary content), `grid-end` (end of the primary content).
  - **Mobile**: 2-column grid with padding on either side. Only implement the lines `grid-start` (start of the primary content), `grid-end` (end of the primary content). (TODO: Probably should also have lines for full-end and full-start but we don't have a use case right now).
- Use new AppsPageSection component for Hero as a test
- Update Hero implementation to use `grid-column` and `grid-row` to place elements relative to the new 6-column grid. 

**Additional Changes in PR:**
- Remove `main` usage on the value-prop section, since there's a lot of other stuff on the page and I'm not sure this make sense any more.
- Switch the approach for adding the background image to use `background-image`. I felt that it was simpler to handle all of the background image and placement in SCSS vs. having an element for it in the markup.


### Verification
- Compare the new implementation of the Hero to the current implementation deployed on madebynota.com to ensure that things looked very similar across different breakpoints. 