### PR TITLE
Updated image section details

### DIFF
--- a/src/components/AppsPage/AppsPage.tsx
+++ b/src/components/AppsPage/AppsPage.tsx
@@ -12,6 +12,7 @@ import { appsPageData, featuresData } from "../../data";
 import "../../styles/PageStyles/apps.scss";
 import { openDemoForm } from "../../utils/global";
 
+<<<<<<< HEAD
 export const AppsPage: React.FC<PageProps> = () => (
   <Layout hasHeader={false}>
     <HeroSection />
@@ -57,3 +58,48 @@ export const AppsPage: React.FC<PageProps> = () => (
     </div>
   </Layout>
 );
+=======
+export const AppsPage: React.FC<PageProps> = () => {
+  return (
+    <Layout hasHeader={false}>
+      <HeroSection />
+      <div className="apps-container">
+        {appsPageData.map((block) => (
+          <ImageTextBlock
+            key={block.label}
+            label={block.label}
+            header={block.header}
+            body={block.body}
+            image={block.image}
+          />
+        ))}
+      </div>
+      <div className="feature-section">
+        <div className="site-section">
+          <Text className="feature-section__header" type="h3" mobileType="h6">
+            Enhance your event experience
+          </Text>
+          <div className="feature-section__grid">
+            {featuresData.map((feature) => (
+              <FeatureBlock
+                iconSrc={feature.iconSrc}
+                title={feature.title}
+                description={feature.description}
+                key={feature.title}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="demo-section">
+        <div className="site-section">
+          <Text className="demo-section__header" type="h2" mobileType="h6">
+            Looking to build something amazing? So are we.
+          </Text>
+          <Button buttonLabel="request demo" onClick={openDemoForm} />
+        </div>
+      </div>
+    </Layout>
+  );
+};
+>>>>>>> 4404bd3 (Updated image section details)

--- a/src/components/AppsPage/AppsPage.tsx
+++ b/src/components/AppsPage/AppsPage.tsx
@@ -12,53 +12,6 @@ import { appsPageData, featuresData } from "../../data";
 import "../../styles/PageStyles/apps.scss";
 import { openDemoForm } from "../../utils/global";
 
-<<<<<<< HEAD
-export const AppsPage: React.FC<PageProps> = () => (
-  <Layout hasHeader={false}>
-    <HeroSection />
-    <div className="apps-container">
-      { appsPageData.map(block => (
-        <ImageTextBlock
-          key={block.label}
-          label={block.label}
-          header={block.header}
-          body={block.body}
-          image={block.image}
-        />
-      ))}
-    </div>
-    <div className="feature-section">
-      <div className="site-section">
-        <Text
-          className="feature-section__header"
-          type="h3"
-          mobileType="h6"
-        >Enhance your event experience</Text>
-        <div className="feature-section__grid">
-          {featuresData.map(feature => (
-            <FeatureBlock
-              iconSrc={feature.iconSrc}
-              title={feature.title}
-              description={feature.description}
-              key={feature.title}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-    <div className="demo-section">
-      <div className="site-section">
-        <Text
-          className="demo-section__header"
-          type="h2"
-          mobileType="h6"
-        >Looking to build something amazing?  So are we.</Text>
-        <Button buttonLabel="request demo" onClick={openDemoForm}/>
-      </div>
-    </div>
-  </Layout>
-);
-=======
 export const AppsPage: React.FC<PageProps> = () => {
   return (
     <Layout hasHeader={false}>
@@ -102,4 +55,3 @@ export const AppsPage: React.FC<PageProps> = () => {
     </Layout>
   );
 };
->>>>>>> 4404bd3 (Updated image section details)

--- a/src/components/ImageTextBlock/ImageTextBlockStyles.scss
+++ b/src/components/ImageTextBlock/ImageTextBlockStyles.scss
@@ -13,6 +13,20 @@
       color: $bic_black;
     }
 
+    .h4 {
+      margin-top: 0;
+      margin-bottom: $spacing-medium;
+    }
+
+    .h2 {
+      margin-top: 0;
+      margin-bottom: $spacing-x-small;
+    }
+
+    .p_large {
+      margin-top: 0;
+    }
+
     @include breakpoint("mobile") {
       padding: 0;
     }
@@ -28,6 +42,8 @@
     img {
       width: 100%;
       height: auto;
+      border-radius: 0.5rem;
+      box-shadow: 0 0.25rem 0.25rem rgba(0,0,0,0.25);
     }
   }
 

--- a/src/styles/PageStyles/apps.scss
+++ b/src/styles/PageStyles/apps.scss
@@ -2,7 +2,7 @@
 @import "../variables.scss";
 
 .apps-container {
-  padding: $spacing-x-large 0;
+  padding: $spacing-xxx-large 0;
 }
 
 .demo-section {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -100,6 +100,7 @@ h6, .h6 {
 .p_large {
   @include bodyText;
   font-size: $p-large;
+  line-height: 125%;
 }
 
 p, .p {


### PR DESCRIPTION
* Added drop shadow and border radius to images
* Matched text margins to mocks
* Increased page top/bottom margins
* Changed p_large line height to be closer to the mocks

In the current version of the mocks we have it set to 100% but that feels a bit tight. 125% feels like a good in-between. 