### PR TITLE
mobile styling tweaks

### DIFF
--- a/src/components/AppsPage/AppsPage.tsx
+++ b/src/components/AppsPage/AppsPage.tsx
@@ -29,12 +29,10 @@ export const AppsPage: React.FC<PageProps> = () => {
         ))}
       </div>
       <AppsPageSection className="feature-section">
-        <Text
-          className="feature-section__header"
-          type="h2"
-          mobileType="h5"
-        >Enhance your event experience</Text>
-        {featuresData.map(feature => (
+        <Text className="feature-section__header" type="h2" mobileType="h5">
+          Enhance your event experience
+        </Text>
+        {featuresData.map((feature) => (
           <FeatureBlock
             iconSrc={feature.iconSrc}
             title={feature.title}

--- a/src/components/FeatureBlock/FeatureBlockStyles.scss
+++ b/src/components/FeatureBlock/FeatureBlockStyles.scss
@@ -25,13 +25,21 @@
     }
   }
 
+  @include breakpoint("mobile") {
+    &:nth-last-child(n + 2) {
+      margin-bottom: $spacing-large;
+    }
+  }
+
   &__img {
     width: 3.125rem;
     height: 3.125rem;
     max-width: 3.125rem;
     max-height: 3.125rem;
 
-    svg, g, path {
+    svg,
+    g,
+    path {
       stroke: $bic_off_white;
     }
   }

--- a/src/components/HeroSection/HeroSection.scss
+++ b/src/components/HeroSection/HeroSection.scss
@@ -10,6 +10,10 @@
 
   // Creating rows in the explicit grid for the benefit of using the full possibilities of grid-row.
   grid-template-rows: repeat(2, minmax(0, auto));
+
+  @include breakpoint("mobile") {
+    padding-bottom: $spacing-x-large;
+  }
 }
 
 .nota-hero-logo {
@@ -33,7 +37,8 @@
   }
 }
 
-.headline, .subheadline {
+.headline,
+.subheadline {
   text-overflow: ellipsis;
   overflow: hidden;
 }
@@ -72,6 +77,12 @@
 
   @include breakpoint("mobile") {
     display: none;
+  }
+}
+
+.hero-cta-button {
+  @include breakpoint("mobile") {
+    margin-bottom: 0;
   }
 }
 

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -17,10 +17,14 @@ export const HeroSection = () => (
         <img src={mobileImg} />
       </div>
       <Text className="subheadline" type="h3" mobileType="p">
-        Nota is powering the next generation of event apps for organizers
-        and attendees
+        Nota is powering the next generation of event apps for organizers and
+        attendees
       </Text>
-      <Button buttonLabel="request demo" onClick={openDemoForm} />
+      <Button
+        buttonLabel="request demo"
+        className="hero-cta-button"
+        onClick={openDemoForm}
+      />
     </div>
     <div className="image-section">
       <img src={heroImg} />

--- a/src/components/ImageTextBlock/ImageTextBlockStyles.scss
+++ b/src/components/ImageTextBlock/ImageTextBlockStyles.scss
@@ -43,7 +43,7 @@
       width: 100%;
       height: auto;
       border-radius: 0.5rem;
-      box-shadow: 0 0.25rem 0.25rem rgba(0,0,0,0.25);
+      box-shadow: 0 0.25rem 0.25rem rgba(0, 0, 0, 0.25);
     }
   }
 
@@ -71,5 +71,9 @@
 
   @include breakpoint("mobile") {
     display: block;
+
+    &:nth-last-child(n + 2) {
+      margin-bottom: $spacing-x-large;
+    }
   }
 }

--- a/src/styles/PageStyles/apps.scss
+++ b/src/styles/PageStyles/apps.scss
@@ -3,6 +3,10 @@
 
 .apps-container {
   padding: $spacing-xxx-large 0;
+
+  @include breakpoint("mobile") {
+    padding: $spacing-x-large 0;
+  }
 }
 
 .demo-section {
@@ -47,7 +51,7 @@
     width: 0.75rem;
     height: 0.75rem;
     transition: 0.3s;
-  
+
     svg {
       display: none;
     }
@@ -59,6 +63,10 @@
 
   &.apps-page-section {
     padding: $spacing-xxx-large 0;
+
+    @include breakpoint("mobile") {
+      padding: $spacing-x-large 0;
+    }
   }
 
   &__header.text {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -110,6 +110,6 @@ body {
   }
 
   .demo-section {
-    padding: $spacing-small;
+    padding: $spacing-x-large 0;
   }
 }


### PR DESCRIPTION
didn't grid-ify cta footer

<img width="574" alt="Screenshot 2024-01-29 at 17 27 33" src="https://github.com/madebynota/portfolio/assets/3255833/4a519b94-23a8-4248-8c9a-15f5ac3c2232">
<img width="604" alt="Screenshot 2024-01-29 at 17 27 28" src="https://github.com/madebynota/portfolio/assets/3255833/85ee38d4-794c-4b50-9fc6-f9ea89c96128">
<img width="579" alt="Screenshot 2024-01-29 at 17 27 21" src="https://github.com/madebynota/portfolio/assets/3255833/49349402-48a0-4bd4-b064-9bad2c341fb6">
<img width="606" alt="Screenshot 2024-01-29 at 17 27 09" src="https://github.com/madebynota/portfolio/assets/3255833/28abda03-187a-4671-bc9e-2c89502b9bb8">
