### PR TITLE
Using Tally for Demo Request form instead of Monday

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,7 +3,5 @@ import logo from "../../images/dialup-retro-logo.png";
 import "./HeaderStyles.scss";
 
 export const Header: React.FC = () => (
-  <header className="site-section header">
-    <img className="logo" src={logo} alt="Dial Up Logo" />
-  </header>
+  <header className="site-section header"></header>
 );

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,3 +1,3 @@
 export const openDemoForm = () => {
-  window.open('https://iu4ccybpfjn.typeform.com/to/DWuo404A', '_blank')?.focus();
+  window.open('https://tally.so/r/3jyaba', '_blank')?.focus();
 };

--- a/src/utils/global.ts
+++ b/src/utils/global.ts
@@ -1,3 +1,3 @@
 export const openDemoForm = () => {
-  window.open('https://forms.monday.com/forms/e4aecd01ca582fa2f7d386930fff44ad?r=use1', '_blank')?.focus();
+  window.open('https://iu4ccybpfjn.typeform.com/to/DWuo404A', '_blank')?.focus();
 };


### PR DESCRIPTION
This PR replaces the form we were using with our Monday account to accept Demo Requests with another form built with Tally that does the exact same thing

ALSO !!!

Locally I was still seeing the old Dial Up wordmark on the /apps page - I removed an explicit reference to that image that lived in `Header.tsx`. Someone please let me know if that's ok to remove!